### PR TITLE
Enable working tests including travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+.tox
+.coverage
+*.egg-info
+docs/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+dist: xenial
+language: python
+install:
+      - pip install tox
+script:
+      - tox
+matrix:
+    include:
+        - python: 2.7
+          env: TOXENV=py27
+        - python: 3.4
+          env: TOXENV=py34
+        - python: 3.5
+          env: TOXENV=py35
+        - python: 3.6
+          env: TOXENV=py36
+        - python: 3.7
+          env: TOXENV=py37
+        - python: pypy
+          env: TOXENV=pypy
+          dist: trusty
+        - python: pypy3
+          env: TOXENV=pypy3
+          dist: trusty

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, pypy
+envlist = py27, py34, py35, py36, py37, pypy, pypy3
 
 [testenv]
 deps =
@@ -12,7 +12,6 @@ deps =
     PasteDeploy
     six
     nose
-    py26,py27,pypy: Cheetah
-    py26,py27,pypy: unittest2
+    py27,pypy: unittest2
 commands =
     nosetests {posargs:-v tests/}


### PR DESCRIPTION
Update tox.ini to modern python versions.
Add .travis.yml to start travi-ci based testing.