### PR TITLE
Remove unittest2 dependency

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,8 +1,0 @@
-syntax: glob
-*.pyc
-*.egg-info/
-*.egg
-.tox
-build/
-dist/
-docs/_build/

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -11,11 +11,7 @@ import six
 import sys
 import tempfile
 import textwrap
-try:
-    # Use unittest2 for Python 2 to get assertRegex() and assertIn() methods
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 
 @contextlib.contextmanager
@@ -294,7 +290,7 @@ class PostTest(unittest.TestCase):
         ''').strip()
         html_regex = '\n%s\n' % html_regex
         html_regex = re.compile(html_regex, re.DOTALL)
-        self.assertRegex(out, html_regex)
+        six.assertRegex(self, out, html_regex)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,5 @@ deps =
     PasteDeploy
     six
     nose
-    py27,pypy: unittest2
 commands =
     nosetests {posargs:-v tests/}


### PR DESCRIPTION
We try to remove the usage of unittest2 package in openSUSE as it is quite dead and replacing it with living alternatives where possible.