### PR TITLE
Make 'python setup.py test' work without error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[nosetests]
+tests=tests

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ deps =
     six
     nose
 commands =
-    nosetests {posargs:-v tests/}
+    nosetests {posargs:-v}


### PR DESCRIPTION
Nose needs to know where to discover tests, which can
be done by adding the appropriate directory to setup.cfg.

Fixes #3