### PR TITLE
Replace WSGIUtils with WSGIServer for python3 compatibility

### DIFF
--- a/paste/script/wsgiutils_server.py
+++ b/paste/script/wsgiutils_server.py
@@ -5,14 +5,15 @@ from paste.translogger import TransLogger
 
 def run_server(wsgi_app, global_conf, host='localhost',
                port=8080):
-    from wsgiutils import wsgiServer
+    import wsgiserver
+
     logged_app = TransLogger(wsgi_app)
     port = int(port)
     # For some reason this is problematic on this server:
     ensure_port_cleanup([(host, port)], maxtries=2, sleeptime=0.5)
     app_map = {'': logged_app}
-    server = wsgiServer.WSGIServer((host, port), app_map)
+    server = wsgiserver.WSGIServer(logged_app, host=host, port=port)
     logged_app.logger.info('Starting HTTP server on http://%s:%s',
                            host, port)
-    server.serve_forever()
+    server.start()
 

--- a/paste/script/wsgiutils_server.py
+++ b/paste/script/wsgiutils_server.py
@@ -11,7 +11,6 @@ def run_server(wsgi_app, global_conf, host='localhost',
     port = int(port)
     # For some reason this is problematic on this server:
     ensure_port_cleanup([(host, port)], maxtries=2, sleeptime=0.5)
-    app_map = {'': logged_app}
     server = wsgiserver.WSGIServer(logged_app, host=host, port=port)
     logged_app.logger.info('Starting HTTP server on http://%s:%s',
                            host, port)

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
       'Templating': [],
       'Cheetah': ['Cheetah'],
       'Config': ['PasteDeploy'],
-      'WSGIUtils': ['WSGIUtils'],
+      'WSGIUtils': ['WSGIserver'],
       'Flup': ['Flup'],
       # the Paste feature means the complete set of features;
       # (other features are truly optional)


### PR DESCRIPTION
WSGUtils is not compatible with python3 while WSGIServer is compatible with both python2 and python3