### PR TITLE
Update the homepage of the project, pointing to its documentation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     keywords='web wsgi setuptools framework command-line setup',
     author="Ian Bicking",
     author_email="ianb@colorstudy.com",
-    url="http://pythonpaste.org/script/",
+    url="https://pastescript.readthedocs.io/",
     namespace_packages=['paste'],
     license='MIT',
     packages=find_packages(exclude=['tests','tests.*']),


### PR DESCRIPTION
According to [Paste](https://pypi.org/project/Paste/), the home page is pointing to its documentation,

so for concistency, I suggests it can follow the pattern.

 Fixes #8 