### PR TITLE
Open, read and write files in binary mode.

### DIFF
--- a/paste/script/copydir.py
+++ b/paste/script/copydir.py
@@ -112,7 +112,6 @@ def copy_dir(source, dest, vars, verbosity, simulate, indent=0,
             content = pkg_resources.resource_string(source[0], full)
             content = content.encode()
         else:
-            print(full)
             with open(full, 'rb') as f:
                 content = f.read()
         if sub_file:


### PR DESCRIPTION
Paster breaks while copying [some] binary files (copydir.py).

In Python 3, opening files with the "r" flag produces strings on read.  To do so, the file content is decoded using utf-8 by default.  Some files, like .jpg images may not be valid utf8, and so cause breakage.

This patch suggests that files are always opened and read in binary (rb) mode, and only decoded for processing if we know they are intended to be used templates.  Everything else is simply written back as a bytestream.